### PR TITLE
Add wrappers for libspline functions

### DIFF
--- a/pyspline/pyVolume.py
+++ b/pyspline/pyVolume.py
@@ -925,7 +925,7 @@ class Volume(object):
         s : float
             Parametric position along 'direction' to insert
         r : int
-        Desired number of times to insert.
+            Desired number of times to insert.
 
         Returns
         -------

--- a/pyspline/utils.py
+++ b/pyspline/utils.py
@@ -350,15 +350,15 @@ def line(*args, **kwargs):
             Error("Error: dir must be specified if only 1 argument is given")
 
 
-def plane_line(pts_T, vec_T, p0, v1, v2):
+def plane_line(ia, vc, p0, v1, v2):
     """
     Check a plane against multiple lines
 
     Parameters
     ----------
-    pt : vector
+    ia : vector
         initial point
-    upVec : vector
+    vc : vector
         search vector from initial point
     p0 : vector
         vector to triangle origins
@@ -371,11 +371,11 @@ def plane_line(pts_T, vec_T, p0, v1, v2):
     -------
     sol
         Solution vector - parametric positions + physical coordiantes
-    nsol
+    nSol
         Number of solutions
     """
 
-    return libspline.plane_line(pts_T, vec_T, p0, v1, v2)
+    return libspline.plane_line(ia, vc, p0, v1, v2)
 
 
 def tfi2d(e0, e1, e2, e3):
@@ -400,15 +400,15 @@ def tfi2d(e0, e1, e2, e3):
     return libspline.tfi2d(e0, e1, e2, e3)
 
 
-def line_plane(pt, upVec, p0, v1, v2):
+def line_plane(ia, vc, p0, v1, v2):
     r"""
     Check a line against multiple planes.
     Solve for the scalars :math:`\alpha, \beta, \gamma` such that
 
     .. math::
 
-        ia + \alpha \times v_c &= p_0 + \beta \times v_1 + \gamma \times v_2 \\
-        ia - p_0 &= \begin{bmatrix}-v_c & v_1 & v_2\end{bmatrix}\begin{bmatrix}\alpha\\\beta\\\gamma\end{bmatrix}\\
+        i_a + \alpha \times v_c &= p_0 + \beta \times v_1 + \gamma \times v_2 \\
+        i_a - p_0 &= \begin{bmatrix}-v_c & v_1 & v_2\end{bmatrix}\begin{bmatrix}\alpha\\\beta\\\gamma\end{bmatrix}\\
         \alpha &\ge 0: \text{The point lies above the initial point}\\
         \alpha  &< 0: \text{The point lies below the initial point}
 
@@ -426,9 +426,9 @@ def line_plane(pt, upVec, p0, v1, v2):
 
     Parameters
     ----------
-    pt : vector
+    ia : vector
         initial point
-    upVec : vector
+    vc : vector
         search vector from initial point
     p0 : vector
         vector to triangle origins
@@ -441,8 +441,8 @@ def line_plane(pt, upVec, p0, v1, v2):
     -------
     sol
         Solution vector---parametric positions + physical coordinates
-    nsol
+    nSol
         Number of solutions
     """
 
-    return libspline.line_plane(pt, upVec, p0, v1, v2)
+    return libspline.line_plane(ia, vc, p0, v1, v2)

--- a/pyspline/utils.py
+++ b/pyspline/utils.py
@@ -349,51 +349,97 @@ def line(*args, **kwargs):
 
 
 def plane_line(pts_T, vec_T, p0, v1, v2):
-    """Check a plane against multiple lines
-    Python wrapper for libspline function
-
-    Args:
-        pts_T ([real]): [description]
-        vec_T ([real]): [description]
-        p0 ([real]): [description]
-        v1 ([real]): [description]
-        v2 ([real]): [description]
-
-    Returns:
-        [int]: [description]
-        [real]: [description]
     """
+    Python wrapper for libspline function plane_line
+
+    libspline plane_line checks a plane against multiple lines]
+
+    Parameters
+    ----------
+    pt : vector
+        initial point
+    upVec : vector
+        search vector from initial point
+    p0 : vector
+        vector to triangle origins
+    v1 : vector
+        vector along first triangle direction
+    v2 : vector
+        vector along second triangle direction
+
+    Returns
+    -------
+    sol
+        Solution vector - parametric positions + physical coordiantes
+    nsol
+        Number of solutions
+    """
+
     return libspline.plane_line(pts_T, vec_T, p0, v1, v2)
 
 
 def tfi2d(e0, e1, e2, e3):
-    """[summary]
+    """
+    Python wrapper for libspline function tfi2d
 
-    Args:
-        e0 ([type]): [description]
-        e1 ([type]): [description]
-        e2 ([type]): [description]
-        e3 ([type]): [description]
+    libspline tfi2d performs a simple 2D transfinite interpolation in 3D.
 
-    Returns:
-        [type]: [description]
+    Parameters
+    ----------
+    e0 : vector, 3 x Nu
+        coordinates along 0th edge
+    e1 : vector, 3 x Nu
+        coordinates along 1st edge
+    e2 : vector, 3 x Nv
+        coordinates along 2nd edge
+    e3 : vector, 3 x Nv
+        coordinates along 3rd edge
+
+    Returns
+    -------
+    vector, 3 x Nu x Nv
+        [description]
     """
     return libspline.tfi2d(e0, e1, e2, e3)
 
 
 def line_plane(pt, upVec, p0, v1, v2):
-    """[summary]
-
-    Args:
-        pt ([type]): [description]
-        upVec ([type]): [description]
-        p0 ([type]): [description]
-        v1 ([type]): [description]
-        v2 ([type]): [description]
-
-    Returns:
-        [type]: [description]
-        [type]: [description]
-        [type]: [description]
     """
+    Python wrapper for libspline function line_plane
+
+    libspline line_plane checks a line against multiple planes
+    Solve for the scalars: alpha, beta, gamma such that:
+        ia + alpha*vc = p0 + beta*v1 + gamma*v2
+        ia - p0 = [ - vc ; v1 ; v2 ][ alpha ]
+                                    [ beta  ]
+                                    [ gamma ]
+    alpha >= 0: The point lies above the initial point
+    alpha  < 0: The point lies below the initial point
+
+    The domain of the triangle is defined by:
+       beta + gamma = 1
+    and
+       0 < beta, gamma < 1
+
+    Parameters
+    ----------
+    pt : vector
+        initial point
+    upVec : vector
+        search vector from initial point
+    p0 : vector
+        vector to triangle origins
+    v1 : vector
+        vector along first triangle direction
+    v2 : vector
+        vector along second triangle direction
+
+    Returns
+    -------
+    sol
+        Solution vector - parametric positions + physical coordiantes
+    nsol
+        Number of solutions
+    """
+
     return libspline.line_plane(pt, upVec, p0, v1, v2)

--- a/pyspline/utils.py
+++ b/pyspline/utils.py
@@ -403,11 +403,11 @@ def tfi2d(e0, e1, e2, e3):
 def line_plane(pt, upVec, p0, v1, v2):
     r"""
     Check a line against multiple planes.
-    Solve for the scalars: alpha, beta, gamma such that
+    Solve for the scalars :math:`\alpha, \beta, \gamma` such that
 
     .. math::
 
-        ia + \alpha*vc &= p_0 + \beta*v_1 + \gamma*v_2 \\
+        ia + \alpha \times v_c &= p_0 + \beta \times v_1 + \gamma \times v_2 \\
         ia - p_0 &= \begin{bmatrix}-v_c & v_1 & v_2\end{bmatrix}\begin{bmatrix}\alpha\\\beta\\\gamma\end{bmatrix}\\
         \alpha &\ge 0: \text{The point lies above the initial point}\\
         \alpha  &< 0: \text{The point lies below the initial point}

--- a/pyspline/utils.py
+++ b/pyspline/utils.py
@@ -356,22 +356,22 @@ def plane_line(ia, vc, p0, v1, v2):
 
     Parameters
     ----------
-    ia : vector
+    ia : ndarray[3, n]
         initial point
-    vc : vector
+    vc : ndarray[3, n]
         search vector from initial point
-    p0 : vector
+    p0 : ndarray[3]
         vector to triangle origins
-    v1 : vector
+    v1 : ndarray[3]
         vector along first triangle direction
-    v2 : vector
+    v2 : ndarray[3]
         vector along second triangle direction
 
     Returns
     -------
-    sol
+    sol : ndarray[6, n]
         Solution vector - parametric positions + physical coordiantes
-    nSol
+    nSol : int
         Number of solutions
     """
 
@@ -384,18 +384,19 @@ def tfi2d(e0, e1, e2, e3):
 
     Parameters
     ----------
-    e0 : vector, 3 x Nu
+    e0 : ndarray[3, Nu]
         coordinates along 0th edge
-    e1 : vector, 3 x Nu
+    e1 : ndarray[3, Nu]
         coordinates along 1st edge
-    e2 : vector, 3 x Nv
+    e2 : ndarray[3, Nv]
         coordinates along 2nd edge
-    e3 : vector, 3 x Nv
+    e3 : ndarray[3, Nv]
         coordinates along 3rd edge
 
     Returns
     -------
-    vector, 3 x Nu x Nv
+    X : ndarray[3 x Nu x Nv]
+        evaluated points
     """
     return libspline.tfi2d(e0, e1, e2, e3)
 
@@ -426,23 +427,24 @@ def line_plane(ia, vc, p0, v1, v2):
 
     Parameters
     ----------
-    ia : vector
+    ia : ndarray[3]
         initial point
-    vc : vector
+    vc : ndarray[3]
         search vector from initial point
-    p0 : vector
+    p0 : ndarray[3, n]
         vector to triangle origins
-    v1 : vector
+    v1 : ndarray[3, n]
         vector along first triangle direction
-    v2 : vector
+    v2 : ndarray[3, n]
         vector along second triangle direction
 
     Returns
     -------
-    sol
+    sol : real ndarray[6, n]
         Solution vector---parametric positions + physical coordinates
-    nSol
+    nSol : int
         Number of solutions
+    pid : int ndarray[n]
     """
 
     return libspline.line_plane(ia, vc, p0, v1, v2)

--- a/pyspline/utils.py
+++ b/pyspline/utils.py
@@ -1,6 +1,8 @@
 # External modules
 import numpy as np
 from scipy import sparse
+
+# Local modules
 from . import libspline
 
 

--- a/pyspline/utils.py
+++ b/pyspline/utils.py
@@ -352,9 +352,7 @@ def line(*args, **kwargs):
 
 def plane_line(pts_T, vec_T, p0, v1, v2):
     """
-    Python wrapper for libspline function plane_line
-
-    libspline plane_line checks a plane against multiple lines]
+    Check a plane against multiple lines
 
     Parameters
     ----------
@@ -382,9 +380,7 @@ def plane_line(pts_T, vec_T, p0, v1, v2):
 
 def tfi2d(e0, e1, e2, e3):
     """
-    Python wrapper for libspline function tfi2d
-
-    libspline tfi2d performs a simple 2D transfinite interpolation in 3D.
+    Perform a simple 2D transfinite interpolation in 3D.
 
     Parameters
     ----------
@@ -400,28 +396,33 @@ def tfi2d(e0, e1, e2, e3):
     Returns
     -------
     vector, 3 x Nu x Nv
-        [description]
     """
     return libspline.tfi2d(e0, e1, e2, e3)
 
 
 def line_plane(pt, upVec, p0, v1, v2):
-    """
-    Python wrapper for libspline function line_plane
+    r"""
+    Check a line against multiple planes.
+    Solve for the scalars: alpha, beta, gamma such that
 
-    libspline line_plane checks a line against multiple planes
-    Solve for the scalars: alpha, beta, gamma such that:
-        ia + alpha*vc = p0 + beta*v1 + gamma*v2
-        ia - p0 = [ - vc ; v1 ; v2 ][ alpha ]
-                                    [ beta  ]
-                                    [ gamma ]
-    alpha >= 0: The point lies above the initial point
-    alpha  < 0: The point lies below the initial point
+    .. math::
 
-    The domain of the triangle is defined by:
-       beta + gamma = 1
+        ia + \alpha*vc &= p_0 + \beta*v_1 + \gamma*v_2 \\
+        ia - p_0 &= \begin{bmatrix}-v_c & v_1 & v_2\end{bmatrix}\begin{bmatrix}\alpha\\\beta\\\gamma\end{bmatrix}\\
+        \alpha &\ge 0: \text{The point lies above the initial point}\\
+        \alpha  &< 0: \text{The point lies below the initial point}
+
+    The domain of the triangle is defined by
+
+    .. math::
+
+       \beta + \gamma = 1
+
     and
-       0 < beta, gamma < 1
+
+    .. math::
+
+       0 < \beta, \gamma < 1
 
     Parameters
     ----------
@@ -439,7 +440,7 @@ def line_plane(pt, upVec, p0, v1, v2):
     Returns
     -------
     sol
-        Solution vector - parametric positions + physical coordiantes
+        Solution vector---parametric positions + physical coordinates
     nsol
         Number of solutions
     """

--- a/pyspline/utils.py
+++ b/pyspline/utils.py
@@ -1,6 +1,7 @@
 # External modules
 import numpy as np
 from scipy import sparse
+from . import libspline
 
 
 class Error(Exception):
@@ -345,3 +346,54 @@ def line(*args, **kwargs):
             return Curve(coef=[args[0], x2], k=2, t=[0, 0, 1, 1])
         else:
             Error("Error: dir must be specified if only 1 argument is given")
+
+
+def plane_line(pts_T, vec_T, p0, v1, v2):
+    """Check a plane against multiple lines
+    Python wrapper for libspline function
+
+    Args:
+        pts_T ([real]): [description]
+        vec_T ([real]): [description]
+        p0 ([real]): [description]
+        v1 ([real]): [description]
+        v2 ([real]): [description]
+
+    Returns:
+        [int]: [description]
+        [real]: [description]
+    """
+    return libspline.plane_line(pts_T, vec_T, p0, v1, v2)
+
+
+def tfi2d(e0, e1, e2, e3):
+    """[summary]
+
+    Args:
+        e0 ([type]): [description]
+        e1 ([type]): [description]
+        e2 ([type]): [description]
+        e3 ([type]): [description]
+
+    Returns:
+        [type]: [description]
+    """
+    return libspline.tfi2d(e0, e1, e2, e3)
+
+
+def line_plane(pt, upVec, p0, v1, v2):
+    """[summary]
+
+    Args:
+        pt ([type]): [description]
+        upVec ([type]): [description]
+        p0 ([type]): [description]
+        v1 ([type]): [description]
+        v2 ([type]): [description]
+
+    Returns:
+        [type]: [description]
+        [type]: [description]
+        [type]: [description]
+    """
+    return libspline.line_plane(pt, upVec, p0, v1, v2)

--- a/src/projections.F90
+++ b/src/projections.F90
@@ -1327,7 +1327,7 @@ subroutine line_plane(ia, vc, p0, v1, v2, n, sol, pid, n_sol)
   ! Check a line against multiple planes
   !
   ! ia:   The initial point
-  ! vc:   The serach vector from the initial point
+  ! vc:   The search vector from the initial point
   ! p0:   Vectors to the triangle origins
   ! v1:   Vector along the first triangle direction
   ! v2:   Vector along the second triangle direction


### PR DESCRIPTION
## Purpose
Closes #23.
Added functions to `utils.py` so codes outside of pyspline can call them instead of directly accessing libspline.
Corresponding pull requests:
- [pyLayout](https://github.com/mdolab/pylayout/pull/14) 
- pyGeo (adding after other pyGeo PR wraps up)

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [X] Maintenance update
- [ ] Other (please describe)


## Checklist
- [X] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [X] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
