### PR TITLE
Another libspline wrapper

### DIFF
--- a/pyspline/__init__.py
+++ b/pyspline/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 from .pyCurve import Curve
 from .pySurface import Surface

--- a/pyspline/utils.py
+++ b/pyspline/utils.py
@@ -402,7 +402,7 @@ def tfi2d(e0, e1, e2, e3):
 
 
 def line_plane(ia, vc, p0, v1, v2):
-    r"""
+    """
     Check a line against multiple planes.
     Solve for the scalars :math:`\alpha, \beta, \gamma` such that
 
@@ -448,3 +448,24 @@ def line_plane(ia, vc, p0, v1, v2):
     """
 
     return libspline.line_plane(ia, vc, p0, v1, v2)
+
+
+def searchQuads(pts0, conn, points):
+    """[summary]
+
+    Parameters
+    ----------
+    pts0 : [type]
+        [description]
+    conn : [type]
+        [description]
+    points : [type]
+        [description]
+
+    Returns
+    -------
+    [type]
+        [description]
+    """
+
+    return libspline.adtprojections.searchquads(pts0, conn, points)

--- a/pyspline/utils.py
+++ b/pyspline/utils.py
@@ -450,25 +450,26 @@ def line_plane(ia, vc, p0, v1, v2):
     return libspline.line_plane(ia, vc, p0, v1, v2)
 
 
-def searchQuads(pts0, conn, searchPts):
-    """This routine searches for the closest point on a set of quads for each searchPt.
-        An ADT tree is built and used for the search and subsequently destroyed.
+def searchQuads(pts, conn, searchPts):
+    """
+    This routine searches for the closest point on a set of quads for each searchPt.
+    An ADT tree is built and used for the search and subsequently destroyed.
 
     Parameters
     ----------
-    pts0 : ndarray[3, n]
-        [description]
-    conn : [type]
-        [description]
-    searchPts : ndarray[3, n]
+    pts : ndarray[3, nPts]
+        points defining the quad elements
+    conn : ndarray[4, nConn]
+        local connectivity of the quad elements
+    searchPts : ndarray[3, nSearchPts]
         set of points to search for
 
     Returns
     -------
-    faceID : int
-        index of the corresponding quad element
-    uv : ndarray[2]
-        parametric u and v weights of the projected point
+    faceID : ndarray[nSearchPts]
+        index of the quad elements, one for each search point
+    uv : ndarray[2, nSearchPts]
+        parametric ``u`` and ``v`` weights of the projected point on the closest quad
     """
 
-    return libspline.adtprojections.searchquads(pts0, conn, searchPts)
+    return libspline.adtprojections.searchquads(pts, conn, searchPts)

--- a/pyspline/utils.py
+++ b/pyspline/utils.py
@@ -450,22 +450,25 @@ def line_plane(ia, vc, p0, v1, v2):
     return libspline.line_plane(ia, vc, p0, v1, v2)
 
 
-def searchQuads(pts0, conn, points):
-    """[summary]
+def searchQuads(pts0, conn, searchPts):
+    """This routine searches for the closest point on a set of quads for each searchPt.
+        An ADT tree is built and used for the search and subsequently destroyed.
 
     Parameters
     ----------
-    pts0 : [type]
+    pts0 : ndarray[3, n]
         [description]
     conn : [type]
         [description]
-    points : [type]
-        [description]
+    searchPts : ndarray[3, n]
+        set of points to search for
 
     Returns
     -------
-    [type]
-        [description]
+    faceID : int
+        index of the corresponding quad element
+    uv : ndarray[2]
+        parametric u and v weights of the projected point
     """
 
-    return libspline.adtprojections.searchquads(pts0, conn, points)
+    return libspline.adtprojections.searchquads(pts0, conn, searchPts)

--- a/pyspline/utils.py
+++ b/pyspline/utils.py
@@ -402,7 +402,7 @@ def tfi2d(e0, e1, e2, e3):
 
 
 def line_plane(ia, vc, p0, v1, v2):
-    """
+    r"""
     Check a line against multiple planes.
     Solve for the scalars :math:`\alpha, \beta, \gamma` such that
 


### PR DESCRIPTION
## Purpose
Closes #23.

Added `searchQuads`, which calls the corresponding libspline function, to `utils.py` so `DVGeometryVSP` can call it instead of directly accessing libspline.

This wrapper was missed in the previous [PR](https://github.com/mdolab/pyspline/pull/29).

Corresponding pull requests:
- [pyGeo](https://github.com/mdolab/pygeo/pull/95) 

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [X] Maintenance update
- [ ] Other (please describe)


## Checklist
- [X] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [X] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation

