### PR TITLE
Change CC compiler to icc for Intel config

### DIFF
--- a/config/defaults/config.LINUX_GFORTRAN.mk
+++ b/config/defaults/config.LINUX_GFORTRAN.mk
@@ -9,7 +9,7 @@ FF90_FLAGS  = -fdefault-real-8 -O2 -fPIC -std=f2008
 
 # C compiler and flags
 CC       = gcc
-CC_FLAGS   = -O2 -fPIC
+CC_FLAGS   = -O2 -fPIC -std=c99
 
 # Define potentially different python, python-config and f2py executables:
 PYTHON = python
@@ -17,5 +17,5 @@ PYTHON-CONFIG = python3-config # use python-config for python 2
 F2PY = f2py
 
 # Define additional flags for linking
-LINKER_FLAGS = 
+LINKER_FLAGS =
 SO_LINKER_FLAGS =-fPIC -shared

--- a/config/defaults/config.LINUX_INTEL.mk
+++ b/config/defaults/config.LINUX_INTEL.mk
@@ -9,7 +9,7 @@ FF90_FLAGS  = -r8 -O2 -fPIC -stand f08
 
 # C compiler and flags
 CC       = icc
-CC_FLAGS   = -O2 -fPIC
+CC_FLAGS   = -O2 -fPIC -std=c99
 
 # Define potentially different python, python-config and f2py executables:
 PYTHON = python

--- a/config/defaults/config.LINUX_INTEL.mk
+++ b/config/defaults/config.LINUX_INTEL.mk
@@ -8,7 +8,7 @@ FF90        = ifort
 FF90_FLAGS  = -r8 -O2 -fPIC -stand f08
 
 # C compiler and flags
-CC       = gcc
+CC       = icc
 CC_FLAGS   = -O2 -fPIC
 
 # Define potentially different python, python-config and f2py executables:
@@ -17,5 +17,5 @@ PYTHON-CONFIG = python3-config # use python-config for python 2
 F2PY = f2py
 
 # Define additional flags for linking
-LINKER_FLAGS = 
+LINKER_FLAGS =
 SO_LINKER_FLAGS =-fPIC -shared

--- a/config/defaults/config.LINUX_INTEL_SCINET.mk
+++ b/config/defaults/config.LINUX_INTEL_SCINET.mk
@@ -9,7 +9,7 @@ FF90_FLAGS  = -r8 -O2 -fPIC
 
 # C compiler and flags
 CC       = icc
-CC_FLAGS   = -O2 -fPIC
+CC_FLAGS   = -O2 -fPIC -std=c99
 
 # Define potentially different python, python-config and f2py executables:
 PYTHON = python

--- a/config/defaults/config.LINUX_INTEL_SCINET.mk
+++ b/config/defaults/config.LINUX_INTEL_SCINET.mk
@@ -8,7 +8,7 @@ FF90        = ifort
 FF90_FLAGS  = -r8 -O2 -fPIC
 
 # C compiler and flags
-CC       = gcc
+CC       = icc
 CC_FLAGS   = -O2 -fPIC
 
 # Define potentially different python, python-config and f2py executables:
@@ -17,5 +17,5 @@ PYTHON-CONFIG = python3-config # use python-config for python 2
 F2PY = f2py
 
 # Define additional flags for linking
-LINKER_FLAGS = 
+LINKER_FLAGS =
 SO_LINKER_FLAGS =-fPIC -shared

--- a/config/defaults/config.OSX_GFORTRAN.mk
+++ b/config/defaults/config.OSX_GFORTRAN.mk
@@ -9,7 +9,7 @@ FF90_FLAGS  = -fdefault-real-8 -O2 -fPIC
 
 # C compiler and flags
 CC       = gcc
-CC_FLAGS   = -O2 -fPIC
+CC_FLAGS   = -O2 -fPIC -std=c99
 
 # Define potentially different python, python-config and f2py executables:
 PYTHON = python
@@ -17,5 +17,5 @@ PYTHON-CONFIG = python3-config # use python-config for python 2
 F2PY = f2py
 
 # Define additional flags for linking
-LINKER_FLAGS = 
+LINKER_FLAGS =
 SO_LINKER_FLAGS=-fPIC -dynamiclib -single_module -undefined dynamic_lookup -multiply_defined suppress


### PR DESCRIPTION
## Purpose
This PR updates the Intel default config to use the Intel compiler `icc` instead of `gcc`. 
The C flags are also updated to support numpy/f2py wrappers > 1.21.

## Expected time until merged
Should be quick, once tests pass.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
