### PR TITLE
Formatting with black 23.1.0

### DIFF
--- a/pyspline/pySurface.py
+++ b/pyspline/pySurface.py
@@ -72,7 +72,6 @@ class Surface(object):
     """
 
     def __init__(self, recompute=True, **kwargs):
-
         self.name = None
         self.edgeCurves = [None, None, None, None]
         self.data = None
@@ -734,7 +733,6 @@ class Surface(object):
                 Surface(tu=t2, tv=self.tv, ku=self.ku, kv=self.kv, coef=coef2),
             )
         elif direction == "v":
-
             r, breakPt = self.insertKnot(direction, s, self.kv - 1)
             # Break point is now at the right so we need to adjust the
             # counter to the left

--- a/tests/reg_tests/test_curves.py
+++ b/tests/reg_tests/test_curves.py
@@ -97,7 +97,6 @@ class Test(unittest.TestCase):
             self.regression_test(handler)
 
     def regression_test(self, handler):
-
         # print('+--------------------------------------+')
         # print('           Create Tests   ')
         # print('+--------------------------------------+')

--- a/tests/reg_tests/test_surfaces.py
+++ b/tests/reg_tests/test_surfaces.py
@@ -153,7 +153,6 @@ class Test(unittest.TestCase):
             self.regression_test(handler)
 
     def regression_test(self, handler, solve=False):
-
         # Create a generic surface
         nu = 10
         nv = 10

--- a/tests/reg_tests/test_volumes.py
+++ b/tests/reg_tests/test_volumes.py
@@ -66,7 +66,6 @@ class Test(unittest.TestCase):
             self.regression_test(handler)
 
     def regression_test(self, handler, solve=False):
-
         # Define raw data for a volume:
         data = np.array(
             [
@@ -2173,7 +2172,6 @@ class Test(unittest.TestCase):
         for ku in [2, 4]:
             for kv in [3, 4]:
                 for kw in [2, 4]:
-
                     # get the knot vectors to initialize the volume using X
                     tu = uniformKnots(X.shape[0], ku)
                     tv = uniformKnots(X.shape[1], kv)


### PR DESCRIPTION
## Purpose
Per title.

## Expected time until merged
Quick, only whitespace changes.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
