### PR TITLE
Adjust docstrings for RST render

### DIFF
--- a/pyspline/utils.py
+++ b/pyspline/utils.py
@@ -29,6 +29,7 @@ class Error(Exception):
 
 def writeTecplot1D(handle, name, data, solutionTime=None):
     """A Generic function to write a 1D data zone to a tecplot file.
+
     Parameters
     ----------
     handle : file handle
@@ -55,6 +56,7 @@ def writeTecplot1D(handle, name, data, solutionTime=None):
 
 def writeTecplot2D(handle, name, data, solutionTime=None):
     """A Generic function to write a 2D data zone to a tecplot file.
+
     Parameters
     ----------
     handle : file handle
@@ -83,6 +85,7 @@ def writeTecplot2D(handle, name, data, solutionTime=None):
 
 def writeTecplot3D(handle, name, data, solutionTime=None):
     """A Generic function to write a 3D data zone to a tecplot file.
+
     Parameters
     ----------
     handle : file handle
@@ -454,9 +457,10 @@ def line_plane(ia, vc, p0, v1, v2):
     -------
     sol : real ndarray[6, n]
         Solution vector---parametric positions + physical coordinates
+    pid : int ndarray[n]
+        Id for a given solution
     nSol : int
         Number of solutions
-    pid : int ndarray[n]
     """
 
     return libspline.line_plane(ia, vc, p0, v1, v2)


### PR DESCRIPTION
## Purpose
This PR fixes broken docstrings in the API documentation, e.g., [here](https://mdolab-pyspline.readthedocs-hosted.com/en/latest/API/utils.html#pyspline.utils.writeTecplot3D) . 

## Expected time until merged
1 day

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
