### PR TITLE
Specified tolerances in assert_allclose calls

### DIFF
--- a/tests/reg_tests/test_curves.py
+++ b/tests/reg_tests/test_curves.py
@@ -47,7 +47,9 @@ def run_curve_test(crv, handler, test_name):
     b = 0.9
     curve_windowed = crv.windowCurve(a, b)
     c = 0.2
-    assert_allclose(crv(c), curve_windowed((c - a) / (b - a)), err_msg="points do not match after windowing!")
+    assert_allclose(
+        crv(c), curve_windowed((c - a) / (b - a)), rtol=1e-7, atol=1e-15, err_msg="points do not match after windowing!"
+    )
 
     # Split the curve in two:
     curve1, curve2 = crv.splitCurve(0.5)
@@ -55,14 +57,14 @@ def run_curve_test(crv, handler, test_name):
     c2 = curve2(0.0)
     c3 = crv(0.5)
     # These three points should be the same (split curve test)
-    assert_allclose(c1, c2, err_msg="points do not match after splitting curve")
-    assert_allclose(c1, c3, err_msg="points do not match after splitting curve")
+    assert_allclose(c1, c2, rtol=1e-7, atol=1e-15, err_msg="points do not match after splitting curve")
+    assert_allclose(c1, c3, rtol=1e-7, atol=1e-15, err_msg="points do not match after splitting curve")
 
     # Reverse test:
     c1 = crv(0.4)
     crv.reverse()
     c2 = crv(0.6)
-    assert_allclose(c1, c2, err_msg="points do not match after reversing curve")
+    assert_allclose(c1, c2, rtol=1e-7, atol=1e-15, err_msg="points do not match after reversing curve")
 
 
 def run_project_test(crv, handler, test_name):

--- a/tests/reg_tests/test_surfaces.py
+++ b/tests/reg_tests/test_surfaces.py
@@ -64,8 +64,20 @@ def run_surface_test(surface, handler, test_name):
 
     surf2 = surface.windowSurface([0.25, 0.25], [0.75, 0.5])
     # these values should be the same
-    assert_allclose(surface(0.25, 0.25), surf2(0, 0), err_msg="surface coordinates do not match after windowing!")
-    assert_allclose(surface(0.75, 0.5), surf2(1, 1), err_msg="surface coordinates do not match after windowing!")
+    assert_allclose(
+        surface(0.25, 0.25),
+        surf2(0, 0),
+        rtol=1e-7,
+        atol=1e-15,
+        err_msg="surface coordinates do not match after windowing!",
+    )
+    assert_allclose(
+        surface(0.75, 0.5),
+        surf2(1, 1),
+        rtol=1e-7,
+        atol=1e-15,
+        err_msg="surface coordinates do not match after windowing!",
+    )
 
     # Test get bounds
     handler.root_add_val("{} bounds".format(test_name), surface.getBounds())


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
After updating the `latest` NumPy version to 1.25.2 (mdolab/docker#233), some of the tests fail marginally on Azure (see logs [here](https://dev.azure.com/mdolab/Public/_build/results?buildId=6421&view=logs&j=0149f092-92cd-5e61-2cc7-e29480811131&t=cb2db150-ac1f-5a6a-43b4-317b997bb116)).

The problem is that some of the `assert_allclose` calls are using the default `atol=0` and there are some values in the arrays that are not exactly zero but less than 1e-15. I added `atol=1e-15` to these calls to fix this. I also added `rtol=1e-7`, which is the default, for clarity.

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->
Current tests should pass on Azure

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
